### PR TITLE
Allow usage of an external qualifier for peripherals

### DIFF
--- a/blessed/src/main/java/com/welie/blessed/BluetoothCentralManager.kt
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothCentralManager.kt
@@ -47,7 +47,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 @SuppressLint("MissingPermission")
 @Suppress("unused")
-class BluetoothCentralManager(private val context: Context, private val bluetoothCentralManagerCallback: BluetoothCentralManagerCallback, private val callBackHandler: Handler) {
+class BluetoothCentralManager(private val context: Context, private val bluetoothCentralManagerCallback: BluetoothCentralManagerCallback, private val callBackHandler: Handler): PeripheralQualifier {
     private val bluetoothAdapter: BluetoothAdapter
 
     @Volatile
@@ -976,6 +976,10 @@ class BluetoothCentralManager(private val context: Context, private val bluetoot
             }
             BluetoothAdapter.STATE_TURNING_ON -> Logger.d(TAG, "bluetooth turning on")
         }
+    }
+
+    override fun isDeviceAPeripheral(device: BluetoothDevice): Boolean {
+        return unconnectedPeripherals.containsKey(device.address)
     }
 
     init {

--- a/blessed/src/main/java/com/welie/blessed/BluetoothPeripheralManager.kt
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothPeripheralManager.kt
@@ -84,7 +84,7 @@ class BluetoothPeripheralManager(
                     // First check if this is a connecting peripheral because Android
                     // will also call this callback for connecting peripherals
                     if (peripheralQualifier?.isDeviceAPeripheral(device) == true) {
-                        Logger.v(TAG, "Device ${device.name} is a peripheral, ignoring STATE_CONNECTED event")
+                        Logger.v(TAG, "Device ${device.name} / ${device.address} is a peripheral, ignoring STATE_CONNECTED event")
                         return
                     }
 

--- a/blessed/src/main/java/com/welie/blessed/BluetoothPeripheralManager.kt
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothPeripheralManager.kt
@@ -47,14 +47,18 @@ import java.util.concurrent.ConcurrentLinkedQueue
  */
 @SuppressLint("MissingPermission")
 @Suppress("unused", "deprecation")
-class BluetoothPeripheralManager(private val context: Context, private val bluetoothManager: BluetoothManager, private val callback: BluetoothPeripheralManagerCallback) {
+class BluetoothPeripheralManager(
+    private val context: Context,
+    private val bluetoothManager: BluetoothManager,
+    private val callback: BluetoothPeripheralManagerCallback,
+    private var peripheralQualifier: PeripheralQualifier? = null,
+) {
     private val mainHandler = Handler(Looper.getMainLooper())
     private val bluetoothAdapter: BluetoothAdapter = bluetoothManager.adapter
     private val bluetoothLeAdvertiser: BluetoothLeAdvertiser = bluetoothAdapter.bluetoothLeAdvertiser
     var isAdvertising: Boolean = false
         private set
 
-    private var centralManager: BluetoothCentralManager? = null
     private val commandQueue: Queue<Runnable> = ConcurrentLinkedQueue()
     private val writeLongCharacteristicTemporaryBytes = HashMap<BluetoothGattCharacteristic, ByteArray>()
     private val writeLongDescriptorTemporaryBytes = HashMap<BluetoothGattDescriptor, ByteArray>()
@@ -69,7 +73,7 @@ class BluetoothPeripheralManager(private val context: Context, private val bluet
     private var commandQueueBusy = false
 
     internal var queuedCommands: Int = 0
-        get() =  commandQueue.size
+        get() = commandQueue.size
         private set
 
     val bluetoothGattServerCallback: BluetoothGattServerCallback = object : BluetoothGattServerCallback() {
@@ -79,10 +83,9 @@ class BluetoothPeripheralManager(private val context: Context, private val bluet
 
                     // First check if this is a connecting peripheral because Android
                     // will also call this callback for connecting peripherals
-                    centralManager?.let {
-                        if (it.unconnectedPeripherals.containsKey(device.address)) {
-                            return
-                        }
+                    if (peripheralQualifier?.isDeviceAPeripheral(device) == true) {
+                        Logger.v(TAG, "Device ${device.name} is a peripheral, ignoring STATE_CONNECTED event")
+                        return
                     }
 
                     // Call connect() even though we are already connected
@@ -396,8 +399,8 @@ class BluetoothPeripheralManager(private val context: Context, private val bluet
         mainHandler.post { callback.onAdvertisingStopped() }
     }
 
-    fun setCentralManager(central: BluetoothCentralManager) {
-        centralManager = Objects.requireNonNull(central)
+    fun setPeripheralQualifier(qualifier: PeripheralQualifier) {
+        peripheralQualifier = qualifier
     }
 
     /**
@@ -804,7 +807,7 @@ class BluetoothPeripheralManager(private val context: Context, private val bluet
         return missingPermissions.toTypedArray()
     }
 
-     val requiredPermissions: Array<String>
+    val requiredPermissions: Array<String>
         get() {
             val targetSdkVersion = context.applicationInfo.targetSdkVersion
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && targetSdkVersion >= Build.VERSION_CODES.S) {

--- a/blessed/src/main/java/com/welie/blessed/PeripheralQualifier.kt
+++ b/blessed/src/main/java/com/welie/blessed/PeripheralQualifier.kt
@@ -1,0 +1,23 @@
+package com.welie.blessed
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGattServerCallback
+
+/**
+ * A PeripheralQualifier instance is used by the [BluetoothPeripheralManager] to discriminate peripheral devices from
+ * central devices.
+ *
+ * The [peripheral manager][BluetoothPeripheralManager] needs to connect to every central that connects to the server,
+ * in order to prevent connectivity issues. See https://issuetracker.google.com/issues/37127644
+ * However, this can cause some issues if the application is used as a BLE server, and a BLE client. Android sends
+ * notifications to the [BluetoothGattServerCallback] for every device connected to the system, peripherals and centrals.
+ * See https://github.com/weliem/blessed-android/issues/156
+ */
+fun interface PeripheralQualifier {
+    /**
+     * Determines whether the given [device] is a peripheral device or a central one.
+     * If the device is a peripheral, the [peripheral manager][BluetoothPeripheralManager] will not initiate a
+     * connection to it.
+     */
+    fun isDeviceAPeripheral(device: BluetoothDevice): Boolean
+}


### PR DESCRIPTION
The base library proposes a mechanism to ignore peripherals connection notifications in the server part. However, this requires using the library to connect to devices too, which is not our case.

This PR adds the possibility to provide an external qualifier for peripherals. Since `BluetoothCentralManager` was the way the qualification was done previously, it now implements the new  `PeripheralQualifier` interface.

Once validated, I might open the same PR on the official repository.